### PR TITLE
feat: recoverer middleware

### DIFF
--- a/middlewarex/recoverer.go
+++ b/middlewarex/recoverer.go
@@ -1,0 +1,40 @@
+package middlewarex
+
+import (
+	"errors"
+	"net/http"
+)
+
+type ErrorHandler func(w http.ResponseWriter, r *http.Request, err error)
+
+func Recoverer(errorHandler ErrorHandler) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if rvr := recover(); rvr != nil {
+					if rvr == http.ErrAbortHandler {
+						// Don’t recover http.ErrAbortHandler so the response to
+						// the client is aborted.
+						panic(rvr)
+					}
+
+					var err error
+					switch x := rvr.(type) {
+					case string:
+						err = errors.New(x)
+					case error:
+						err = x
+					default:
+						err = errors.New("unknown panic")
+					}
+
+					errorHandler(w, r, err)
+				}
+			}()
+
+			next.ServeHTTP(w, r)
+		}
+
+		return http.HandlerFunc(fn)
+	}
+}

--- a/middlewarex/recoverer_test.go
+++ b/middlewarex/recoverer_test.go
@@ -1,0 +1,62 @@
+package middlewarex
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecoverer_WithPlainTextError(t *testing.T) {
+	plainTextErrorHandler := func(w http.ResponseWriter, r *http.Request, err error) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal server error: " + err.Error()))
+	}
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	})
+
+	h := Recoverer(plainTextErrorHandler)(next)
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	res := w.Result()
+	assert.Equal(t, res.StatusCode, http.StatusInternalServerError)
+	assert.Equal(t, w.Body.String(), "internal server error: test panic")
+}
+
+func TestRecoverer_WithJSONError(t *testing.T) {
+	type ErrorResponse struct {
+		Status  int    `json:"status"`
+		Message string `json:"message"`
+	}
+
+	jsonErrorHandler := func(w http.ResponseWriter, r *http.Request, err error) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(ErrorResponse{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		})
+	}
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	})
+
+	h := Recoverer(jsonErrorHandler)(next)
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	res := w.Result()
+	var responseBody ErrorResponse
+	_ = json.NewDecoder(res.Body).Decode(&responseBody)
+
+	assert.Equal(t, res.StatusCode, http.StatusInternalServerError)
+	assert.Equal(t, http.StatusInternalServerError, responseBody.Status)
+	assert.Equal(t, "test panic", responseBody.Message)
+}

--- a/middlewarex/recoverer_test.go
+++ b/middlewarex/recoverer_test.go
@@ -8,7 +8,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRecoverer_WithPlainTextError(t *testing.T) {
+func TestRecovererAbortHandler(t *testing.T) {
+	defer func() {
+		rcv := recover()
+		if rcv != http.ErrAbortHandler {
+			t.Fatalf("http.ErrAbortHandler should not be recovered")
+		}
+	}()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(http.ErrAbortHandler)
+	})
+
+	h := Recoverer(nil)(next)
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+}
+
+func TestRecovererCustomErrorResponse(t *testing.T) {
 	plainTextErrorHandler := func(w http.ResponseWriter, r *http.Request, err error) {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte("internal server error: " + err.Error()))

--- a/middlewarex/recoverer_test.go
+++ b/middlewarex/recoverer_test.go
@@ -1,7 +1,6 @@
 package middlewarex
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -27,36 +26,4 @@ func TestRecoverer_WithPlainTextError(t *testing.T) {
 	res := w.Result()
 	assert.Equal(t, res.StatusCode, http.StatusInternalServerError)
 	assert.Equal(t, w.Body.String(), "internal server error: test panic")
-}
-
-func TestRecoverer_WithJSONError(t *testing.T) {
-	type ErrorResponse struct {
-		Status  int    `json:"status"`
-		Message string `json:"message"`
-	}
-
-	jsonErrorHandler := func(w http.ResponseWriter, r *http.Request, err error) {
-		w.WriteHeader(http.StatusInternalServerError)
-		_ = json.NewEncoder(w).Encode(ErrorResponse{
-			Status:  http.StatusInternalServerError,
-			Message: err.Error(),
-		})
-	}
-
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		panic("test panic")
-	})
-
-	h := Recoverer(jsonErrorHandler)(next)
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, r)
-
-	res := w.Result()
-	var responseBody ErrorResponse
-	_ = json.NewDecoder(res.Body).Decode(&responseBody)
-
-	assert.Equal(t, res.StatusCode, http.StatusInternalServerError)
-	assert.Equal(t, http.StatusInternalServerError, responseBody.Status)
-	assert.Equal(t, "test panic", responseBody.Message)
 }


### PR DESCRIPTION
Introduces a recoverer middleware that handles panics and delegates error response handling to the caller.

Two tests are included: one with a `plain text` error response and another with a `structured JSON` response.
It should also work with a dedicated library like [ory/herodot](https://github.com/ory/herodot).