### PR TITLE
Upgrade to Go 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/HGV/x
 
-go 1.22
+go 1.24
 
 require (
 	github.com/jackc/pgx/v5 v5.7.2


### PR DESCRIPTION
Are you okay with bumping the minimum Go version to 1.24? Almost all of our projects are now using Go 1.24 anyway.